### PR TITLE
fix: remove 8.1 matrix in security workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,6 @@ jobs:
   security:
     uses: dvsa/.github/.github/workflows/php-library-security.yml@v3.2.3
     with:
-      php-versions: "[\"7.4\",\"8.0\", \"8.1\"]"
+      php-versions: "[\"7.4\",\"8.0\"]"
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## Description
Remove the 8.1 matrix from the snyk workflow
<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

+ [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
+ [x] Have you performed a self-review of the code?
+ [ ] Have you have added tests that prove the fix or feature is effective and working?
+ [ ] Did you make sure to update any documentation relating to this change?
